### PR TITLE
Add local view statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 # 3D_portfolio
 # 3D_Portfolio
+
+## Features
+- View count statistics stored locally

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { BrowserRouter } from "react-router-dom";
-import { About, Contact, Experience, Feedbacks, Hero, Navbar, Tech, Works, StarsCanvas } from "./components";
+import { About, Contact, Experience, Feedbacks, Hero, Navbar, Tech, Works, StarsCanvas, Stats } from "./components";
 
 
 
@@ -25,6 +25,7 @@ const App = () => {
         <div className="relative z-0">
           <Contact/>
           <StarsCanvas/>
+          <Stats/>
         </div>
       </div>
     </BrowserRouter>

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from 'react';
+
+const Stats = () => {
+  const [views, setViews] = useState(0);
+
+  useEffect(() => {
+    const storedViews = Number(localStorage.getItem('views') || 0);
+    const newViews = storedViews + 1;
+    localStorage.setItem('views', newViews);
+    setViews(newViews);
+  }, []);
+
+  return (
+    <div className="fixed bottom-2 right-2 bg-tertiary text-white py-1 px-3 rounded shadow-card text-xs">
+      Views: {views}
+    </div>
+  );
+};
+
+export default Stats;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,6 +7,7 @@ import Experience from './Experience';
 import Works from './Works';
 import Feedbacks from './Feedbacks';
 import Contact from './Contact';
+import Stats from './Stats';
 
 
 
@@ -19,8 +20,9 @@ export {
   Works,
   Feedbacks,
   Contact,
-  EarthCanvas, 
-  BallCanvas, 
-  ComputersCanvas, 
+  Stats,
+  EarthCanvas,
+  BallCanvas,
+  ComputersCanvas,
   StarsCanvas
 }


### PR DESCRIPTION
## Summary
- add new `Stats` component to track views using `localStorage`
- export and display `Stats` in `App`
- document the new feature in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688143e107a88329b76970c29b476590